### PR TITLE
Fix: ares flatpak not picking up shaders and database folders

### DIFF
--- a/ares-paths.patch
+++ b/ares-paths.patch
@@ -1,46 +1,3 @@
----
- desktop-ui/desktop-ui.cpp | 2 ++
- mia/mia.cpp               | 9 +++++++--
- nall/path.cpp             | 2 +-
- 3 files changed, 10 insertions(+), 3 deletions(-)
-
-diff --git a/desktop-ui/desktop-ui.cpp b/desktop-ui/desktop-ui.cpp
-index f4ac44202..372e5e386 100644
---- a/desktop-ui/desktop-ui.cpp
-+++ b/desktop-ui/desktop-ui.cpp
-@@ -30,6 +30,8 @@ auto locate(const string& name) -> string {
-   // default to userData, on Windows, default to program dir
-   // this ensures Portable mode is the default on Windows platforms.
-   #if !defined(PLATFORM_WINDOWS)
-+    string shared_location = {Path::sharedData(), "ares/", name};
-+    if(inode::exists(shared_location)) return shared_location;
-     directory::create({Path::userData(), "ares/"});
-     return {Path::userData(), "ares/", name};
-   #else 
-diff --git a/mia/mia.cpp b/mia/mia.cpp
-index 08b6310c3..a2d9f843f 100644
---- a/mia/mia.cpp
-+++ b/mia/mia.cpp
-@@ -28,10 +28,15 @@ auto locate(const string& name) -> string {
-   location = {Path::userData(), "ares/", name};
-   if(inode::exists(location)) return location;
- 
--  // On non-windows platforms, after exhausting other options,
--  // default to userData, on Windows, default to program dir
-+  // On non-windows platforms, this time check the shared
-+  // data directory, on Windows, default to program dir
-   // this ensures Portable mode is the default on Windows platforms.
- #if !defined(PLATFORM_WINDOWS)
-+  string shared_location = {Path::sharedData(), "ares/", name};
-+  if(inode::exists(shared_location)) return shared_location;
-+
-+  // On non-windows platforms, after exhausting other options,
-+  // default to userData
-   directory::create({Path::userData(), "ares/"});
-   return {Path::userData(), "ares/", name};
- #else
-diff --git a/nall/path.cpp b/nall/path.cpp
-index 02a12b9f3..68ca517f2 100644
 --- a/nall/path.cpp
 +++ b/nall/path.cpp
 @@ -119,7 +119,7 @@ NALL_HEADER_INLINE auto sharedData() -> string {
@@ -52,6 +9,5 @@ index 02a12b9f3..68ca517f2 100644
    #endif
    if(!result) result = ".";
    if(!result.endsWith("/")) result.append("/");
--- 
+--
 2.41.0
-

--- a/ares-paths.patch
+++ b/ares-paths.patch
@@ -1,0 +1,70 @@
+---
+ desktop-ui/desktop-ui.cpp | 13 +++++++++++--
+ mia/mia.cpp               | 10 ++++++++--
+ nall/path.cpp             |  2 +-
+ 3 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/desktop-ui/desktop-ui.cpp b/desktop-ui/desktop-ui.cpp
+index f4ac44202..24d109806 100644
+--- a/desktop-ui/desktop-ui.cpp
++++ b/desktop-ui/desktop-ui.cpp
+@@ -26,10 +26,19 @@ auto locate(const string& name) -> string {
+   location = {Path::userData(), "ares/", name};
+   if(inode::exists(location)) return location;
+ 
+-  // On non-windows platforms, after exhausting other options,
+-  // default to userData, on Windows, default to program dir
++  // On non-windows platforms, this time check the shared
++  // data directory, on Windows, default to program dir,
+   // this ensures Portable mode is the default on Windows platforms.
+   #if !defined(PLATFORM_WINDOWS)
++    string shared_location = {Path::sharedData(), "ares/", name};
++    if(inode::exists(shared_location)) return shared_location;
++    // XXX: Change settings.bml location to match Ares' default behavior.
++    if(directory::exists({Path::userSettings(), "ares/"})) {
++      file::copy({Path::userSettings(), "ares/settings.bml"}, {Path::userData(), "ares/settings.bml"});
++    }
++    
++    // On non-windows platforms, after exhausting other options,
++    // default to userData.
+     directory::create({Path::userData(), "ares/"});
+     return {Path::userData(), "ares/", name};
+   #else 
+diff --git a/mia/mia.cpp b/mia/mia.cpp
+index 47d1771bc..a2d9f843f 100644
+--- a/mia/mia.cpp
++++ b/mia/mia.cpp
+@@ -28,10 +28,15 @@ auto locate(const string& name) -> string {
+   location = {Path::userData(), "ares/", name};
+   if(inode::exists(location)) return location;
+ 
+-  // On non-windows platforms, after exhausting other options,
+-  // default to userData, on Windows, default to program dir
++  // On non-windows platforms, this time check the shared
++  // data directory, on Windows, default to program dir
+   // this ensures Portable mode is the default on Windows platforms.
+ #if !defined(PLATFORM_WINDOWS)
++  string shared_location = {Path::sharedData(), "ares/", name};
++  if(inode::exists(shared_location)) return shared_location;
++
++  // On non-windows platforms, after exhausting other options,
++  // default to userData
+   directory::create({Path::userData(), "ares/"});
+   return {Path::userData(), "ares/", name};
+ #else
+diff --git a/nall/path.cpp b/nall/path.cpp
+index 02a12b9f3..68ca517f2 100644
+--- a/nall/path.cpp
++++ b/nall/path.cpp
+@@ -119,7 +119,7 @@ NALL_HEADER_INLINE auto sharedData() -> string {
+   #elif defined(PLATFORM_MACOS)
+   string result = "/Library/Application Support/";
+   #else
+-  string result = "/usr/share/";
++  string result = "/app/share/";
+   #endif
+   if(!result) result = ".";
+   if(!result.endsWith("/")) result.append("/");
+-- 
+2.41.0
+

--- a/ares-paths.patch
+++ b/ares-paths.patch
@@ -1,37 +1,24 @@
 ---
- desktop-ui/desktop-ui.cpp | 13 +++++++++++--
- mia/mia.cpp               | 10 ++++++++--
- nall/path.cpp             |  2 +-
- 3 files changed, 20 insertions(+), 5 deletions(-)
+ desktop-ui/desktop-ui.cpp | 2 ++
+ mia/mia.cpp               | 9 +++++++--
+ nall/path.cpp             | 2 +-
+ 3 files changed, 10 insertions(+), 3 deletions(-)
 
 diff --git a/desktop-ui/desktop-ui.cpp b/desktop-ui/desktop-ui.cpp
-index f4ac44202..24d109806 100644
+index f4ac44202..372e5e386 100644
 --- a/desktop-ui/desktop-ui.cpp
 +++ b/desktop-ui/desktop-ui.cpp
-@@ -26,10 +26,19 @@ auto locate(const string& name) -> string {
-   location = {Path::userData(), "ares/", name};
-   if(inode::exists(location)) return location;
- 
--  // On non-windows platforms, after exhausting other options,
--  // default to userData, on Windows, default to program dir
-+  // On non-windows platforms, this time check the shared
-+  // data directory, on Windows, default to program dir,
+@@ -30,6 +30,8 @@ auto locate(const string& name) -> string {
+   // default to userData, on Windows, default to program dir
    // this ensures Portable mode is the default on Windows platforms.
    #if !defined(PLATFORM_WINDOWS)
 +    string shared_location = {Path::sharedData(), "ares/", name};
 +    if(inode::exists(shared_location)) return shared_location;
-+    // XXX: Change settings.bml location to match Ares' default behavior.
-+    if(directory::exists({Path::userSettings(), "ares/"})) {
-+      file::copy({Path::userSettings(), "ares/settings.bml"}, {Path::userData(), "ares/settings.bml"});
-+    }
-+    
-+    // On non-windows platforms, after exhausting other options,
-+    // default to userData.
      directory::create({Path::userData(), "ares/"});
      return {Path::userData(), "ares/", name};
    #else 
 diff --git a/mia/mia.cpp b/mia/mia.cpp
-index 47d1771bc..a2d9f843f 100644
+index 08b6310c3..a2d9f843f 100644
 --- a/mia/mia.cpp
 +++ b/mia/mia.cpp
 @@ -28,10 +28,15 @@ auto locate(const string& name) -> string {

--- a/dev.ares.ares.metainfo.xml
+++ b/dev.ares.ares.metainfo.xml
@@ -146,6 +146,7 @@
     <binary>ares</binary>
   </provides>
   <releases>
+    <release version="133" date="2023-07-21"/>
     <release version="132" date="2023-03-08"/>
     <release version="131" date="2022-12-27"/>
     <release version="130.1" date="2022-10-03"/>

--- a/dev.ares.ares.yaml
+++ b/dev.ares.ares.yaml
@@ -22,8 +22,8 @@ modules:
     sources:
       - type: archive
         archive-type: tar
-        url: https://api.github.com/repos/ares-emulator/ares/tarball/v132
-        sha256: a69c54608aeee952809059d07039befc124fbf0e127066ada90531e9156539fd
+        url: https://api.github.com/repos/ares-emulator/ares/tarball/v133
+        sha256: 85a96bbee381a48f7b402d2ecbffcb168d5ea343086813a1e637f84b0539b6ed
         x-checker-data:
           type: json
           url: https://api.github.com/repos/ares-emulator/ares/releases/latest
@@ -32,3 +32,5 @@ modules:
           url-query: .tarball_url
       - type: file
         path: dev.ares.ares.metainfo.xml
+      - type: patch
+        path: ares-paths.patch


### PR DESCRIPTION
Closes: https://github.com/flathub/dev.ares.ares/issues/18

Depends on: https://github.com/flathub/dev.ares.ares/pull/28

Some of the patch is ported over from: https://aur.archlinux.org/cgit/aur.git/tree/ares-paths.patch?h=ares-emu

Tested and works ok. 