### PR TITLE
Simplify shader install

### DIFF
--- a/dev.ares.ares.yaml
+++ b/dev.ares.ares.yaml
@@ -45,10 +45,6 @@ modules:
   - name: slang-shaders
     make-install-args: 
       - PREFIX=${FLATPAK_DEST}
-    post-install:
-      - mkdir -p ${FLATPAK_DEST}/share/ares/Shaders && cp -r ${FLATPAK_DEST}/share/libretro/shaders/shaders_slang/* ${FLATPAK_DEST}/share/ares/Shaders
-    cleanup:
-      - /share/libretro
     sources: 
       - type: git
         url: https://github.com/libretro/slang-shaders.git  


### PR DESCRIPTION
* Simplify shader install
    * See https://github.com/ares-emulator/ares/pull/1738
        * No need to copy shaders to a specified directory and do cleanup