### PR TITLE
fix: do not require llvm20 for the build

### DIFF
--- a/dev.ares.ares.yaml
+++ b/dev.ares.ares.yaml
@@ -4,7 +4,6 @@ runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
-  - org.freedesktop.Sdk.Extension.llvm20
 command: ares
 rename-desktop-file: ares.desktop
 rename-icon: ares
@@ -42,9 +41,6 @@ modules:
   - name: ares
     buildsystem: cmake-ninja
     builddir: true
-    build-options:
-      append-path: /usr/lib/sdk/llvm20/bin
-      prepend-ld-library-path: /usr/lib/sdk/llvm20/lib
     config-opts:
       - -W no-dev
       - -D CMAKE_BUILD_TYPE=RelWithDebInfo
@@ -53,8 +49,6 @@ modules:
       - -D ARES_BUILD_LOCAL=OFF
       - -D ARES_BUNDLE_SHADERS=OFF
       - -D ARES_SKIP_DEPS=ON
-      - -D CMAKE_C_COMPILER=clang
-      - -D CMAKE_CXX_COMPILER=clang++
       - -D ARES_BUILD_OFFICIAL=YES
       - -G Ninja
     sources:


### PR DESCRIPTION
We include rust for building librasterizer but LLVM20 is also being pulled, without any need for it. This removes the LLVM20 dependency and changes the default compiled to GCC (the default on the fdsdk runtime), it shouldn't be necessary for building and this makes the build more similar to what other distributions also do (see [arch package](https://gitlab.archlinux.org/archlinux/packaging/packages/ares-emu/-/blob/bfcd9a5b613a92a152c751157274ab2b92c1e41d/PKGBUILD#L51-56), [debian package](https://salsa.debian.org/games-team/ares/-/blob/d646b676287962cb793accba3021198b0c012106/debian/rules#L10-15)). Should align us a little bit more with them.

